### PR TITLE
Initial stab at a Bolt plan for upgrades

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,12 @@
     {
       "name": "exgrizz-artifactory_pro",
       "version_requirement": ">= 99.0.0"
+    },
+    {
+      "name": "puppetlabs-package"
+    },
+    {
+      "name": "puppetlabs-service"
     }
   ],
   "operatingsystem_support": [

--- a/plans/drain_lb.pp
+++ b/plans/drain_lb.pp
@@ -1,0 +1,16 @@
+plan artifactory_ha::drain_lb(
+  TargetSpec $apps,
+  TargetSpec $lb
+) {
+  $app_names = get_targets($apps).map |$t| { $t.host.split('[.]')[0] }
+  $lb_names = get_targets($lb).map |$t| { $t.name }
+
+  # Makes more sense as a task in Puppet using the puppetlabs-haproxy module
+  notice("Draining ${app_names} on ${lb_names}")
+  $app_names.each |$app| {
+    $sed = "sed -i -e '/ *server *${app}/ s/^#*/#/'"
+    run_command("${sed} /etc/haproxy/haproxy.cfg", $lb, _run_as => 'root')
+  }
+  run_command('systemctl restart haproxy', $lb, _run_as => 'root')
+  undef
+}

--- a/plans/restore_lb.pp
+++ b/plans/restore_lb.pp
@@ -1,0 +1,16 @@
+plan artifactory_ha::restore_lb(
+  TargetSpec $apps,
+  TargetSpec $lb
+) {
+  $app_names = get_targets($apps).map |$t| { $t.host.split('[.]')[0] }
+  $lb_names = get_targets($lb).map |$t| { $t.name }
+
+  # Makes more sense as a task in Puppet using the puppetlabs-haproxy module
+  notice("Restoring ${app_names} on ${lb_names}")
+  $app_names.each |$app| {
+    $sed = "sed -i -e '/ *server *${app}/ s/^#*//'"
+    run_command("${sed} /etc/haproxy/haproxy.cfg", $lb, _run_as => 'root')
+  }
+  run_command('systemctl restart haproxy', $lb, _run_as => 'root')
+  undef
+}

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,0 +1,35 @@
+plan artifactory_ha::upgrade(
+  TargetSpec $apps,
+  TargetSpec $lb,
+  String     $version
+) {
+  # Upgrade one at a time
+  $app_targets = get_targets($apps)
+
+  $app_targets.each |$app| {
+    # TODO: disable puppet-agent
+    run_plan(artifactory_ha::drain_lb, apps => $app, lb => $lb)
+
+    $stop_result = run_task(service, $app, action => 'stop', service => 'artifactory', _catch_errors => true)
+    if !$stop_result.ok {
+      run_plan(artifactory_ha::restore_lb, apps => $app, lb => $lb)
+      fail_plan("Failed to stop artifactory on ${app.name}")
+    }
+
+    $upgrade_result = run_task(package, $app, action => 'upgrade', name => 'jfrog-artifactory-pro', version => $version, _catch_errors => true)
+    if !$upgrade_result.ok {
+      run_plan(artifactory_ha::restore_lb, apps => $app, lb => $lb)
+      fail_plan("Failed to upgrade artifactory on ${app.name}")
+    }
+
+    # Don't catch failure, as we wouldn't want to add it to the lb if the service isn't running.
+    run_task(service, $app, action => 'start', service => 'artifactory')
+
+    run_plan(artifactory_ha::restore_lb, apps => $app, lb => $lb)
+    # TODO: enable puppet-agent
+
+    # TODO: verify correct version is running
+  }
+
+  # TODO: verify service is accessible
+}


### PR DESCRIPTION
Handles upgrading application servers one-at-a-time. Drains each from
the load balancer, upgrades the package, and restores it to the lb.

Requires Bolt 0.16.1+.